### PR TITLE
Added and tested write function

### DIFF
--- a/src/dplypy.py
+++ b/src/dplypy.py
@@ -6,7 +6,7 @@ from typing import AnyStr, Callable
 class DplyFrame:
     def __init__(self, pandas_df: pd.DataFrame):
         self.pandas_df = pandas_df
-        self.index = pandas_df.index # TODO: is index necessary?
+        # self.index = pandas_df.index # TODO: is index necessary?
 
     def __eq__(self, other: pd.DataFrame):
         return self.pandas_df == other.pandas_df

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -58,7 +58,7 @@ def write_file(file_path, sep=',', index=True):
     elif file_path.endswith('.pkl'):
         return to_pickle
     else:
-        raise Exception('The file format is not supported.')
+        raise IOError('The file format is not supported.')
 
 
 """

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -23,6 +23,44 @@ def drop(labels=None, axis=0, index=None, columns=None):
     return lambda d1: DplyFrame(d1.pandas_df.drop(labels=labels, axis=axis, index=index, columns=columns))
 
 
+def write_file(file_path, sep=',', index=True):
+    """
+    Write DplyFrame to file.
+
+    Write the DplyFrame to the following file types depending on the file path given: .csv, .xlsx, .json and .pkl.
+
+    :param file_path: the path of the file with proper suffix
+    :param sep: the separator for csv files. Default to be comma
+    :param index: Write the row name by the index of the DplyFrame. Default to be true.
+    """
+    def to_csv(d1):
+        d1.pandas_df.to_csv(file_path, sep=sep, index=index)
+        return d1
+
+    def to_excel(d1):
+        d1.pandas_df.to_excel(file_path, index=index)
+        return d1
+
+    def to_json(d1):
+        d1.pandas_df.to_json(file_path)
+        return d1
+    
+    def to_pickle(d1):
+        d1.pandas_df.to_pickle(file_path)
+        return d1
+
+    if file_path.endswith('.csv'):
+        return to_csv
+    elif file_path.endswith('.xlsx'):
+        return to_excel
+    elif file_path.endswith('.json'):
+        return to_json
+    elif file_path.endswith('.pkl'):
+        return to_pickle
+    else:
+        print("Unfortunately we do not support this file type. Please write the files with the following types: \n")
+        print(".csv\t.json\t.pkl\t.xlsx")
+
 """
 TODO: 
 - API for plotting intermediate transformations?

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -44,7 +44,7 @@ def write_file(file_path, sep=',', index=True):
     def to_json(d1):
         d1.pandas_df.to_json(file_path)
         return d1
-    
+
     def to_pickle(d1):
         d1.pandas_df.to_pickle(file_path)
         return d1
@@ -58,8 +58,8 @@ def write_file(file_path, sep=',', index=True):
     elif file_path.endswith('.pkl'):
         return to_pickle
     else:
-        print("Unfortunately we do not support this file type. Please write the files with the following types: \n")
-        print(".csv\t.json\t.pkl\t.xlsx")
+        raise Exception('The file format is not supported.')
+
 
 """
 TODO: 

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -63,8 +63,3 @@ def write_file(file_path, sep=',', index=True):
         return to_pickle
     else:
         raise IOError('The file format is not supported.')
-
-
-    return lambda d1: DplyFrame(
-        d1.pandas_df.drop(labels=labels, axis=axis, index=index, columns=columns)
-    )

--- a/test/pipeline_test.py
+++ b/test/pipeline_test.py
@@ -1,7 +1,8 @@
 import pandas as pd
 from src.dplypy import DplyFrame
-from src.pipeline import query, apply, drop
+from src.pipeline import query, apply, drop, write_file
 import numpy as np
+import os
 
 
 def _test(): # TODO: convert to pytest 
@@ -40,10 +41,53 @@ def test_drop():
     pd.testing.assert_frame_equal(output3.pandas_df, expected3)
 
     df4 = DplyFrame(pandas_df)
-    output4 = df4 + drop(index=[2, 3])
-    expected4 = pandas_df.drop(index=[2, 3])
+    output4 = df4 + drop(index=[2, 3]) + drop(index=[1])
+    expected4 = pandas_df.drop(index=[1, 2, 3])
     pd.testing.assert_frame_equal(output4.pandas_df, expected4)
 
+
+def test_write_file():
+    pandas_df = pd.DataFrame(data={
+        'col1': [0, 1, 2, 3],
+        'col2': [3, 4, 5, 6],
+        'col3': [6, 7, 8, 9],
+        'col4': [9, 10, 11, 12]
+    })
+
+    df = DplyFrame(pandas_df)
+
+    # To csv file
+    df + write_file('df_no_index.csv', sep=',', index=False) + write_file('df_with_index.csv', sep=',', index=True)
+    read_df = pd.read_csv('df_no_index.csv', sep=',')
+    pd.testing.assert_frame_equal(df.pandas_df, read_df)    # Without index
+    os.remove('df_no_index.csv')
+
+    read_df = pd.read_csv('df_with_index.csv', sep=',', index_col=0)
+    pd.testing.assert_frame_equal(df.pandas_df, read_df)    # With index
+    os.remove('df_with_index.csv')
+
+    # To excel file
+    # Requires dependency openpyxl
+    df + write_file('df_no_index.xlsx', index=False) + write_file('df_with_index.xlsx', index=True)
+    read_df = pd.read_excel('df_no_index.xlsx', engine='openpyxl')
+    pd.testing.assert_frame_equal(df.pandas_df, read_df)    # Without index
+    os.remove('df_no_index.xlsx')
+
+    read_df = pd.read_excel('df_with_index.xlsx', index_col=0, engine='openpyxl')
+    pd.testing.assert_frame_equal(df.pandas_df, read_df)    # Without index
+    os.remove('df_with_index.xlsx')
+
+    # To json
+    df + write_file('df_no_index.json')
+    read_df = pd.read_json('df_no_index.json')
+    pd.testing.assert_frame_equal(df.pandas_df, read_df)    # Without index
+    os.remove('df_no_index.json')
+
+    # To pickle
+    df + write_file('df_no_index.pkl')
+    read_df = pd.read_pickle('df_no_index.pkl')
+    pd.testing.assert_frame_equal(df.pandas_df, read_df)    # Without index
+    os.remove('df_no_index.pkl')
 
 if __name__ == '__main__':
     test_drop()

--- a/test/pipeline_test.py
+++ b/test/pipeline_test.py
@@ -62,7 +62,8 @@ def test_write_file():
     df = DplyFrame(pandas_df)
 
     # To csv file
-    df + write_file('df_no_index.csv', sep=',', index=False) + write_file('df_with_index.csv', sep=',', index=True)
+    df + write_file('df_no_index.csv', sep=',', index=False) + \
+        write_file('df_with_index.csv', sep=',', index=True)
     read_df = pd.read_csv('df_no_index.csv', sep=',')
     pd.testing.assert_frame_equal(df.pandas_df, read_df)    # Without index
     os.remove('df_no_index.csv')
@@ -73,12 +74,14 @@ def test_write_file():
 
     # To excel file
     # Requires dependency openpyxl
-    df + write_file('df_no_index.xlsx', index=False) + write_file('df_with_index.xlsx', index=True)
+    df + write_file('df_no_index.xlsx', index=False) + \
+        write_file('df_with_index.xlsx', index=True)
     read_df = pd.read_excel('df_no_index.xlsx', engine='openpyxl')
     pd.testing.assert_frame_equal(df.pandas_df, read_df)    # Without index
     os.remove('df_no_index.xlsx')
 
-    read_df = pd.read_excel('df_with_index.xlsx', index_col=0, engine='openpyxl')
+    read_df = pd.read_excel('df_with_index.xlsx',
+                            index_col=0, engine='openpyxl')
     pd.testing.assert_frame_equal(df.pandas_df, read_df)    # Without index
     os.remove('df_with_index.xlsx')
 
@@ -98,9 +101,6 @@ def test_write_file():
     with pytest.raises(IOError) as context:
         new_df = df + write_file('df.abc')
 
-        
-    
-    
 
 if __name__ == '__main__':
     test_drop()

--- a/test/pipeline_test.py
+++ b/test/pipeline_test.py
@@ -89,5 +89,10 @@ def test_write_file():
     pd.testing.assert_frame_equal(df.pandas_df, read_df)    # Without index
     os.remove('df_no_index.pkl')
 
+    # Error case
+    new_df = df + write_file('df.abc')
+    
+    
+
 if __name__ == '__main__':
     test_drop()

--- a/test/pipeline_test.py
+++ b/test/pipeline_test.py
@@ -3,6 +3,7 @@ from src.dplypy import DplyFrame
 from src.pipeline import query, apply, drop, write_file
 import numpy as np
 import os
+import pytest
 
 
 def _test(): # TODO: convert to pytest 
@@ -90,7 +91,10 @@ def test_write_file():
     os.remove('df_no_index.pkl')
 
     # Error case
-    new_df = df + write_file('df.abc')
+    with pytest.raises(IOError) as context:
+        new_df = df + write_file('df.abc')
+
+        
     
     
 


### PR DESCRIPTION
A couple questions for the write_file function:
1. Right now I've implemented functions for writing to csv, json, excel and pickle files. Each file type requires different parameters (like sep for csv), and there are lots of parameters that we could choose to include/not include in our functions.
When you're looking at my code, do you have any ideas of other parameters that we may include in our write_file function?
2. How about other file types?
3. Testing the code requires openpyxl package (pd.read_excel has some kind of dependency on it). Should we specify that somehow to the users as well?